### PR TITLE
Fix remaining Travis problems with Digraphs-v1.0 branch

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -11,7 +11,7 @@
 ##  <#GAPDoc Label="PKGVERSIONDATA">
 ##  <!ENTITY VERSION "3.1.5">
 ##  <!ENTITY GAPVERS "4.9.0">
-##  <!ENTITY DIGRAPHSVERS "0.12.0">
+##  <!ENTITY DIGRAPHSVERS "1.0.0">
 ##  <!ENTITY ORBVERS "4.8.2">
 ##  <!ENTITY IOVERS "4.5.1">
 ##  <!ENTITY GENSSVERS "1.6.5">
@@ -290,7 +290,7 @@ Dependencies := rec(
   GAP := ">=4.9.0",
   NeededOtherPackages := [["orb", ">=4.8.2"],
                           ["io", ">=4.5.1"],
-                          ["digraphs", ">=0.12.0"],
+                          ["digraphs", ">=1.0.0"],
                           ["genss", ">=1.6.5"]],
   SuggestedOtherPackages := [["gapdoc", ">=1.5.1"]],
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ installation of [Semigroups]:
 Both [orb] and [Semigroups] perform better when [orb] is compiled, so compile
 [orb]!
 
-* ensure that the [Digraphs] package version 0.12.0 or higher is available.
+* ensure that the [Digraphs] package version 1.0.0 or higher is available.
   [Digraphs] must be compiled before [Semigroups] can be loaded.
 
 * get the [genss](http://gap-packages.github.io/genss) package version 1.6.5 or

--- a/scripts/travis-build-dependencies.sh
+++ b/scripts/travis-build-dependencies.sh
@@ -59,7 +59,7 @@ CURL="curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-m
 # TEMPORARY: INSTALL DIGRAPHS MASTER BRANCH
 git clone -b master --depth=1 https://github.com/gap-packages/Digraphs.git $GAPROOT/pkg/digraphs
 cd $GAPROOT/pkg/digraphs
-./autogen.sh && ./configure && make
+./autogen.sh && ./configure $PKG_FLAGS && make
 
 ################################################################################
 # Install digraphs, genss, io, orb, and profiling

--- a/tst/workspaces/load-workspace.tst
+++ b/tst/workspaces/load-workspace.tst
@@ -142,9 +142,9 @@ gap> NrTransverseBlocks(b);
 gap> DegreeOfBlocks(b);
 10
 gap> AsDigraph(b);
-<digraph with 10 vertices, 23 edges>
+<immutable digraph with 10 vertices, 23 edges>
 gap> CanonicalBlocks(b);
-<blocks: [ 1*, 2*, 3*, 4* ], [ 5, 6, 7 ], [ 8*, 9* ], [ 10* ]>
+<blocks: [ 1* ], [ 2*, 3* ], [ 4*, 5*, 6*, 7* ], [ 8, 9, 10 ]>
 
 #############################################################################
 ##  Tests end here

--- a/tst/workspaces/save-workspace.tst
+++ b/tst/workspaces/save-workspace.tst
@@ -143,9 +143,9 @@ gap> NrTransverseBlocks(b);
 gap> DegreeOfBlocks(b);
 10
 gap> AsDigraph(b);
-<digraph with 10 vertices, 23 edges>
+<immutable digraph with 10 vertices, 23 edges>
 gap> CanonicalBlocks(b);
-<blocks: [ 1*, 2*, 3*, 4* ], [ 5, 6, 7 ], [ 8*, 9* ], [ 10* ]>
+<blocks: [ 1* ], [ 2*, 3* ], [ 4*, 5*, 6*, 7* ], [ 8, 9, 10 ]>
 
 #############################################################################
 ##  Tests end here


### PR DESCRIPTION
I missed a few things in my last PR, sorry. You may as well wait until the tests here (https://travis-ci.org/wilfwilson/Semigroups/builds/588848093) pass before merging, to have to avoid doing this again, but I expect that it should be fine.

(The tests passed after the commit `Fix remaining Travis problems` https://travis-ci.org/wilfwilson/Semigroups/builds/588841944, and I wouldn't expect the commit `Require Digraphs v1.0.0` to break anything, because the `master` branch of `Digraphs` does carry this version number, and that's the branch that Travis is using at the moment).